### PR TITLE
Fix ETL date parsing and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ This project extracts, transforms, and loads Netflix title data from a CSV file 
 2. **Install dependencies**:
    ```bash
    pip install -r requirements.txt
+   ```

--- a/etl_netflix.py
+++ b/etl_netflix.py
@@ -30,7 +30,7 @@ def run_etl():
     # Clean
     df.drop_duplicates(inplace=True)
     df.fillna('Unknown', inplace=True)
-    df['date_added'] = pd.to_datetime(df['date_added'], format='%B %d, %Y', errors='coerce')
+    df['date_added'] = pd.to_datetime(df['date_added'], errors='coerce')
     df[['duration_int', 'duration_type']] = df['duration'].str.extract(r'(\d+)\s*(\w+)')
     df['duration_int'] = df['duration_int'].fillna(0).astype(int)
 
@@ -44,8 +44,9 @@ def run_etl():
     else:
         logging.info("No new records to insert.")
 
-schedule.every().day.at("10:00").do(run_etl)
+if __name__ == "__main__":
+    schedule.every().day.at("10:00").do(run_etl)
 
-while True:
-    schedule.run_pending()
-    time.sleep(60)
+    while True:
+        schedule.run_pending()
+        time.sleep(60)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-"pandas",
-"sqlalchemy",
-"psycopg2",
-"schedule"
+pandas
+sqlalchemy
+psycopg2
+schedule


### PR DESCRIPTION
## Summary
- fix README setup instructions
- parse `date_added` without a strict format
- protect schedule loop behind `__main__`
- clean up `requirements.txt`

## Testing
- `python -m py_compile etl_netflix.py`

------
https://chatgpt.com/codex/tasks/task_e_6843532bcb0c832fb00d9531b8dc1cec